### PR TITLE
Fix bugs related to late swipe highlighting

### DIFF
--- a/src/overseer/yesql/queries.sql
+++ b/src/overseer/yesql/queries.sql
@@ -89,8 +89,8 @@ SELECT
   c.late_time AS late_time,
   l.last_swipe_type,
   l.last_swipe_date,
-  l.last_swipe_date > (current_date at time zone sch.timezone)::date as swiped_today,
-  l.last_in > ((current_date at time zone sch.timezone)::date + c.late_time) as swiped_today_late
+  l.last_swipe_date > current_date as swiped_today,
+  l.last_in > (current_date + c.late_time) as swiped_today_late
 FROM
   overseer.students stu
   LEFT JOIN (
@@ -270,7 +270,7 @@ SELECT
   cXs.student_id,
   s.name student_name,
   c.required_minutes,
-  ((current_date at time zone sch.timezone)::date + c.late_time) as late_time
+  (current_date + c.late_time) as late_time
 FROM
   overseer.classes c
 LEFT JOIN overseer.schools sch on c.school_id = sch._id

--- a/src/overseer/yesql/queries.sql
+++ b/src/overseer/yesql/queries.sql
@@ -89,8 +89,8 @@ SELECT
   c.late_time AS late_time,
   l.last_swipe_type,
   l.last_swipe_date,
-  l.last_swipe_date > current_date as swiped_today,
-  l.last_in > (current_date + c.late_time) as swiped_today_late
+  l.last_swipe_date > ((current_date + current_time) at time zone sch.timezone)::date as swiped_today,
+  l.last_in > (((current_date + current_time) at time zone sch.timezone)::date + c.late_time) as swiped_today_late
 FROM
   overseer.students stu
   LEFT JOIN (
@@ -270,7 +270,7 @@ SELECT
   cXs.student_id,
   s.name student_name,
   c.required_minutes,
-  (current_date + c.late_time) as late_time
+  (((current_date + current_time) at time zone sch.timezone)::date + c.late_time) as late_time
 FROM
   overseer.classes c
 LEFT JOIN overseer.schools sch on c.school_id = sch._id

--- a/src/overseer/yesql/queries.sql
+++ b/src/overseer/yesql/queries.sql
@@ -89,14 +89,16 @@ SELECT
   c.late_time AS late_time,
   l.last_swipe_type,
   l.last_swipe_date,
-  l.last_swipe_date > current_date as swiped_today,
-  l.last_swipe_date > (current_date + c.late_time) as swiped_today_late
+  l.last_swipe_date > (current_date at time zone sch.timezone)::date as swiped_today,
+  l.last_in > ((current_date at time zone sch.timezone)::date +
+               (c.late_time at time zone sch.timezone)) as swiped_today_late
 FROM
   overseer.students stu
   LEFT JOIN (
   (SELECT
       CASE WHEN subl.outs >= subl.ins THEN 'out' ELSE 'in' END AS last_swipe_type,
       CASE WHEN subl.outs >= subl.ins THEN subl.outs ELSE subl.ins END AS last_swipe_date,
+      subl.ins as last_in,
       subl.student_id
       FROM (SELECT
               max(s.in_time) AS ins,
@@ -108,6 +110,7 @@ FROM
   INNER JOIN overseer.classes c ON (1 = 1)
   INNER JOIN overseer.classes_X_students cXs ON (cXs.student_id = stu._id
           AND cXs.class_id = c._id)
+  INNER JOIN overseer.schools sch on c.school_id=sch._id
   WHERE (stu.archived = :show_archived
         OR stu.archived = FALSE)
     AND c.active = TRUE
@@ -268,9 +271,11 @@ SELECT
   cXs.student_id,
   s.name student_name,
   c.required_minutes,
-  (current_date + c.late_time) as late_time
+  ((current_date at time zone sch.timezone)::date +
+   (c.late_time at time zone sch.timezone)) as late_time
 FROM
   overseer.classes c
+LEFT JOIN overseer.schools sch on c.school_id = sch._id
 LEFT JOIN overseer.classes_X_students cXs ON (cXs.class_id = c._id)
 LEFT JOIN overseer.students s ON (cXs.student_id = s._id)
 WHERE c.school_id = :school_id

--- a/src/overseer/yesql/queries.sql
+++ b/src/overseer/yesql/queries.sql
@@ -90,8 +90,7 @@ SELECT
   l.last_swipe_type,
   l.last_swipe_date,
   l.last_swipe_date > (current_date at time zone sch.timezone)::date as swiped_today,
-  l.last_in > ((current_date at time zone sch.timezone)::date +
-               (c.late_time at time zone sch.timezone)) as swiped_today_late
+  l.last_in > ((current_date at time zone sch.timezone)::date + c.late_time) as swiped_today_late
 FROM
   overseer.students stu
   LEFT JOIN (
@@ -271,8 +270,7 @@ SELECT
   cXs.student_id,
   s.name student_name,
   c.required_minutes,
-  ((current_date at time zone sch.timezone)::date +
-   (c.late_time at time zone sch.timezone)) as late_time
+  ((current_date at time zone sch.timezone)::date + c.late_time) as late_time
 FROM
   overseer.classes c
 LEFT JOIN overseer.schools sch on c.school_id = sch._id


### PR DESCRIPTION
This fixes a couple things: (1) when someone swiped out, `swiped_late_today` became true and their name was highlighted red, and (2) once it past midnight in UTC (7pm Eastern), all red highlighting for the day went away.

This doesn't fix #59 after all. I think the solution to that is to make the late sign in time be an `interval` type, and not a time (with or without time zone).
